### PR TITLE
Remove dependencies for type AtomicInteger

### DIFF
--- a/core/src/main/java/tech/tablesaw/columns/strings/NullDictionaryMap.java
+++ b/core/src/main/java/tech/tablesaw/columns/strings/NullDictionaryMap.java
@@ -1,12 +1,13 @@
 package tech.tablesaw.columns.strings;
 
+import tech.tablesaw.api.BooleanColumn;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.selection.Selection;
+
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-import tech.tablesaw.api.BooleanColumn;
-import tech.tablesaw.api.Table;
-import tech.tablesaw.selection.Selection;
 
 /**
  * A null dictionary map has no actual dictionary as the underlying data is not dictionary encoded.
@@ -204,5 +205,10 @@ public class NullDictionaryMap extends DictionaryMap<Number> {
   @Override
   protected int getByteSize() {
     return 0;
+  }
+
+  @Override
+  protected Number getValueId() throws NoKeysAvailableException {
+    return null;
   }
 }


### PR DESCRIPTION
## target
- DictionaryMap
- ByteDictionaryMap
- ShortDictionaryMap
- IntDictionaryMap
- NullDictionaryMap

## detail
- Remove dependencies for type AtomicInteger
- Convert AtomicInteger to AtomicReference

## reason
- Because the key id is combined with the type of DictionaryMap, AtomicInteger interferes with flexibility
