### PR TITLE
Apply strategy pattern to SortMergeJoinPerformer

### DIFF
--- a/core/src/main/java/tech/tablesaw/joining/SortMergeFullJoin.java
+++ b/core/src/main/java/tech/tablesaw/joining/SortMergeFullJoin.java
@@ -1,0 +1,40 @@
+package tech.tablesaw.joining;
+
+import tech.tablesaw.api.Table;
+import tech.tablesaw.selection.Selection;
+
+public class SortMergeFullJoin extends SortMergeJoinStrategy{
+    private final String LEFT_RECORD_ID_NAME;
+    private final String RIGHT_RECORD_ID_NAME;
+
+    public SortMergeFullJoin(int[] rightJoinColumnPositions, int[] leftJoinColumnPositions,
+                             String LEFT_RECORD_ID_NAME, String RIGHT_RECORD_ID_NAME) {
+        super(rightJoinColumnPositions, leftJoinColumnPositions);
+        this.LEFT_RECORD_ID_NAME = LEFT_RECORD_ID_NAME;
+        this.RIGHT_RECORD_ID_NAME = RIGHT_RECORD_ID_NAME;
+    }
+
+    @Override
+    void perform(Table destination, Table left, Table right, int[] ignoreColumns) {
+        Table tempDestination = destination.emptyCopy();
+
+        joinInner(destination, left, right, ignoreColumns);
+
+        Selection unmatchedLeft =
+                left.intColumn(LEFT_RECORD_ID_NAME)
+                        .isNotIn(destination.intColumn(LEFT_RECORD_ID_NAME).unique());
+        addLeftOnlyValues(destination, left, unmatchedLeft);
+
+        Selection unmatchedRight =
+                right.intColumn(RIGHT_RECORD_ID_NAME)
+                        .isNotIn(destination.intColumn(RIGHT_RECORD_ID_NAME).unique());
+        addRightOnlyValues(tempDestination, left, right, unmatchedRight);
+        for (int i = 0; i < ignoreColumns.length; i++) {
+            String name = tempDestination.columnNames().get(leftJoinColumnPositions[i]);
+            tempDestination.replaceColumn(
+                    leftJoinColumnPositions[i],
+                    tempDestination.column(ignoreColumns[i]).copy().setName(name));
+        }
+        destination.append(tempDestination);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/joining/SortMergeInnerJoin.java
+++ b/core/src/main/java/tech/tablesaw/joining/SortMergeInnerJoin.java
@@ -1,0 +1,15 @@
+package tech.tablesaw.joining;
+
+import tech.tablesaw.api.Table;
+
+public class SortMergeInnerJoin extends SortMergeJoinStrategy{
+
+    public SortMergeInnerJoin(int[] rightJoinColumnPositions, int[] leftJoinColumnPositions) {
+        super(rightJoinColumnPositions, leftJoinColumnPositions);
+    }
+
+    @Override
+    public void perform(Table destination, Table left, Table right, int[] ignoreColumns) {
+        joinInner(destination, left, right, ignoreColumns);
+    }
+}

--- a/core/src/main/java/tech/tablesaw/joining/SortMergeJoin.java
+++ b/core/src/main/java/tech/tablesaw/joining/SortMergeJoin.java
@@ -114,7 +114,7 @@ class SortMergeJoin implements JoinStrategy {
     }
     SortMergeJoinPerformer sortMergeJoinPerformer = new SortMergeJoinPerformer(joinType, LEFT_RECORD_ID_NAME,
             RIGHT_RECORD_ID_NAME, leftJoinColumnPositions, rightJoinColumnPositions);
-    sortMergeJoinPerformer.join(result, table1, table2, resultIgnoreColIndexes);
+    sortMergeJoinPerformer.perform(result, table1, table2, resultIgnoreColIndexes);
     result.removeColumns(LEFT_RECORD_ID_NAME, RIGHT_RECORD_ID_NAME);
 
     if (!keepAllJoinKeyColumns) {

--- a/core/src/main/java/tech/tablesaw/joining/SortMergeJoinPerformer.java
+++ b/core/src/main/java/tech/tablesaw/joining/SortMergeJoinPerformer.java
@@ -1,20 +1,14 @@
 package tech.tablesaw.joining;
 
-import tech.tablesaw.api.ColumnType;
-import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
-import tech.tablesaw.selection.Selection;
-
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
 
 public class SortMergeJoinPerformer {
     JoinType joinType;
-    private String LEFT_RECORD_ID_NAME;
-    private String RIGHT_RECORD_ID_NAME;
-    private int[] leftJoinColumnPositions;
-    private int[] rightJoinColumnPositions;
+    private final String LEFT_RECORD_ID_NAME;
+    private final String RIGHT_RECORD_ID_NAME;
+    private final int[] leftJoinColumnPositions;
+    private final int[] rightJoinColumnPositions;
+    private SortMergeJoinStrategy joinStrategy;
 
     public SortMergeJoinPerformer(JoinType joinType, String LEFT_RECORD_ID_NAME, String RIGHT_RECORD_ID_NAME,
                                   int[] leftJoinColumnPositions, int[] rightJoinColumnPositions){
@@ -25,204 +19,22 @@ public class SortMergeJoinPerformer {
         this.rightJoinColumnPositions = rightJoinColumnPositions;
     }
 
-    public void join(Table result, Table table1, Table table2, int[] resultIgnoreColIndexes){
+    public void setJoinStrategy(SortMergeJoinStrategy joinStrategy) {
+        this.joinStrategy = joinStrategy;
+    }
+
+    public void perform(Table result, Table table1, Table table2, int[] resultIgnoreColIndexes){
         if (joinType == JoinType.INNER) {
-            joinInner(result, table1, table2, resultIgnoreColIndexes);
+            setJoinStrategy(new SortMergeInnerJoin(rightJoinColumnPositions, leftJoinColumnPositions));
         } else if (joinType == JoinType.LEFT_OUTER) {
-            joinLeft(result, table1, table2, resultIgnoreColIndexes);
+            setJoinStrategy(new SortMergeLeftJoin(rightJoinColumnPositions, leftJoinColumnPositions, LEFT_RECORD_ID_NAME));
         } else if (joinType == JoinType.RIGHT_OUTER) {
-            joinRight(result, table1, table2, resultIgnoreColIndexes);
+            setJoinStrategy(new SortMergeRightJoin(rightJoinColumnPositions, leftJoinColumnPositions, RIGHT_RECORD_ID_NAME));
         } else if (joinType == JoinType.FULL_OUTER) {
-            joinFull(result, table1, table2, resultIgnoreColIndexes);
-        }
-    }
-
-    private void joinInner(Table destination, Table left, Table right, int[] ignoreColumns) {
-
-        Comparator<Row> comparator = getRowComparator(left, rightJoinColumnPositions);
-
-        Row leftRow = left.row(0);
-        Row rightRow = right.row(0);
-
-        // Marks the position of the first record in right table that matches a specific join value
-        int mark = -1;
-
-        while (leftRow.hasNext() || rightRow.hasNext()) {
-            if (mark == -1) {
-                while (comparator.compare(leftRow, rightRow) < 0 && leftRow.hasNext()) leftRow.next();
-                while (comparator.compare(leftRow, rightRow) > 0 && rightRow.hasNext()) rightRow.next();
-                // set the position of the first matching record on the right side
-                mark = rightRow.getRowNumber();
-            }
-            if (comparator.compare(leftRow, rightRow) == 0 && (leftRow.hasNext() || rightRow.hasNext())) {
-                addValues(destination, leftRow, rightRow);
-                if (rightRow.hasNext()) {
-                    rightRow.next();
-                } else {
-                    rightRow.at(mark);
-                    if (leftRow.hasNext()) {
-                        leftRow.next();
-                    }
-                    mark = -1;
-                }
-            } else {
-                if (rightRow.hasNext() && leftRow.hasNext()) {
-                    rightRow.at(mark);
-                    leftRow.next();
-                    mark = -1;
-                } else {
-                    if (leftRow.hasNext()) leftRow.next();
-                    if (!leftRow.hasNext()) {
-                        break;
-                    }
-                }
-            }
-        }
-        // add the last value if you end on a match
-        if (comparator.compare(leftRow, rightRow) == 0) {
-            addValues(destination, leftRow, rightRow);
-        }
-    }
-
-    private void joinLeft(Table destination, Table left, Table right, int[] ignoreColumns) {
-
-        joinInner(destination, left, right, ignoreColumns);
-        Selection unmatched =
-                left.intColumn(LEFT_RECORD_ID_NAME)
-                        .isNotIn(destination.intColumn(LEFT_RECORD_ID_NAME).unique());
-        addLeftOnlyValues(destination, left, unmatched);
-    }
-
-    private void joinRight(Table destination, Table left, Table right, int[] ignoreColumns) {
-        joinInner(destination, left, right, ignoreColumns);
-        Selection unmatched =
-                right
-                        .intColumn(RIGHT_RECORD_ID_NAME)
-                        .isNotIn(destination.intColumn(RIGHT_RECORD_ID_NAME).unique());
-        addRightOnlyValues(destination, left, right, unmatched);
-    }
-
-    private void joinFull(Table destination, Table left, Table right, int[] ignoreColumns) {
-
-        Table tempDestination = destination.emptyCopy();
-
-        joinInner(destination, left, right, ignoreColumns);
-
-        Selection unmatchedLeft =
-                left.intColumn(LEFT_RECORD_ID_NAME)
-                        .isNotIn(destination.intColumn(LEFT_RECORD_ID_NAME).unique());
-        addLeftOnlyValues(destination, left, unmatchedLeft);
-
-        Selection unmatchedRight =
-                right
-                        .intColumn(RIGHT_RECORD_ID_NAME)
-                        .isNotIn(destination.intColumn(RIGHT_RECORD_ID_NAME).unique());
-        addRightOnlyValues(tempDestination, left, right, unmatchedRight);
-        for (int i = 0; i < ignoreColumns.length; i++) {
-            String name = tempDestination.columnNames().get(leftJoinColumnPositions[i]);
-            tempDestination.replaceColumn(
-                    leftJoinColumnPositions[i],
-                    tempDestination.column(ignoreColumns[i]).copy().setName(name));
-        }
-        destination.append(tempDestination);
-    }
-
-    private void addLeftOnlyValues(Table destination, Table left, Selection unmatched) {
-        for (Row leftRow : left.where(unmatched)) {
-            Row destRow = destination.appendRow();
-            for (int c = 0; c < leftRow.columnCount() - 1; c++) {
-                updateDestinationRow(destRow, leftRow, c, c);
-            }
-            // update the index column putting it at the end of the destination table
-            updateDestinationRow(destRow, leftRow, destRow.columnCount() - 2, leftRow.columnCount() - 1);
-        }
-    }
-
-    private void addRightOnlyValues(Table destination, Table left, Table right, Selection unmatched) {
-        int leftColumnCount = left.columnCount();
-        for (Row rightRow : right.where(unmatched)) {
-            Row destRow = destination.appendRow();
-            for (int c = 0; c < rightRow.columnCount() - 1; c++) {
-                updateDestinationRow(destRow, rightRow, c + leftColumnCount - 1, c);
-            }
-            // update the index column putting it at the end of the destination table
-            updateDestinationRow(
-                    destRow, rightRow, destRow.columnCount() - 1, rightRow.columnCount() - 1);
-        }
-    }
-
-    private Comparator<Row> getRowComparator(Table left, int[] rightJoinColumnIndexes) {
-        List<ColumnIndexPair> pairs = createJoinColumnPairs(left, rightJoinColumnIndexes);
-        return SortKey.getChain(SortKey.create(pairs));
-    }
-
-    private List<ColumnIndexPair> createJoinColumnPairs(Table left, int[] rightJoinColumnIndexes) {
-        List<ColumnIndexPair> pairs = new ArrayList<>();
-        for (int i = 0; i < leftJoinColumnPositions.length; i++) {
-            ColumnIndexPair columnIndexPair =
-                    new ColumnIndexPair(
-                            left.column(leftJoinColumnPositions[i]).type(),
-                            leftJoinColumnPositions[i],
-                            rightJoinColumnIndexes[i]);
-            pairs.add(columnIndexPair);
-        }
-        return pairs;
-    }
-
-    private void updateDestinationRow(
-            Row destRow, Row sourceRow, int destColumnPosition, int sourceColumnPosition) {
-        ColumnType type = destRow.getColumnType(destColumnPosition);
-        if (type.equals(ColumnType.INTEGER)) {
-            destRow.setInt(destColumnPosition, sourceRow.getInt(sourceColumnPosition));
-        } else if (type.equals(ColumnType.LONG)) {
-            destRow.setLong(destColumnPosition, sourceRow.getLong(sourceColumnPosition));
-        } else if (type.equals(ColumnType.SHORT)) {
-            destRow.setShort(destColumnPosition, sourceRow.getShort(sourceColumnPosition));
-        } else if (type.equals(ColumnType.STRING)) {
-            destRow.setString(destColumnPosition, sourceRow.getString(sourceColumnPosition));
-        } else if (type.equals(ColumnType.LOCAL_DATE)) {
-            destRow.setPackedDate(destColumnPosition, sourceRow.getPackedDate(sourceColumnPosition));
-        } else if (type.equals(ColumnType.LOCAL_TIME)) {
-            destRow.setPackedTime(destColumnPosition, sourceRow.getPackedTime(sourceColumnPosition));
-        } else if (type.equals(ColumnType.LOCAL_DATE_TIME)) {
-            destRow.setPackedDateTime(
-                    destColumnPosition, sourceRow.getPackedDateTime(sourceColumnPosition));
-        } else if (type.equals(ColumnType.INSTANT)) {
-            destRow.setPackedInstant(
-                    destColumnPosition, sourceRow.getPackedInstant(sourceColumnPosition));
-        } else if (type.equals(ColumnType.DOUBLE)) {
-            destRow.setDouble(destColumnPosition, sourceRow.getDouble(sourceColumnPosition));
-        } else if (type.equals(ColumnType.FLOAT)) {
-            destRow.setFloat(destColumnPosition, sourceRow.getFloat(sourceColumnPosition));
-        } else if (type.equals(ColumnType.BOOLEAN)) {
-            destRow.setBooleanAsByte(
-                    destColumnPosition, sourceRow.getBooleanAsByte(sourceColumnPosition));
-        }
-    }
-
-    private void addValues(Table destination, Row leftRow, Row rightRow) {
-
-        Row destRow = destination.appendRow();
-
-        // update positionally, but take into account the RECORD_ID COLUMNS at the end of the dest table
-        int leftColumnCount = leftRow.columnCount();
-        int rightColumnCount = rightRow.columnCount();
-
-        // update from the left table first (everythint but the RECORD_ID column)
-        for (int destIdx1 = 0; destIdx1 < leftColumnCount - 1; destIdx1++) {
-            updateDestinationRow(destRow, leftRow, destIdx1, destIdx1);
+            setJoinStrategy(new SortMergeFullJoin(rightJoinColumnPositions, leftJoinColumnPositions,
+                    LEFT_RECORD_ID_NAME, RIGHT_RECORD_ID_NAME));
         }
 
-        // update from the right table (everythint but the RECORD_ID column)
-        for (int destIdx2 = (leftColumnCount - 1);
-             destIdx2 < (leftColumnCount + rightColumnCount) - 2;
-             destIdx2++) {
-            int rightIndex = destIdx2 - (leftColumnCount - 1);
-            updateDestinationRow(destRow, rightRow, destIdx2, rightIndex);
-        }
-
-        // update the RECORD_ID columns
-        updateDestinationRow(destRow, leftRow, destRow.columnCount() - 2, leftColumnCount - 1);
-        updateDestinationRow(destRow, rightRow, destRow.columnCount() - 1, rightColumnCount - 1);
+        joinStrategy.perform(result, table1, table2, resultIgnoreColIndexes);
     }
 }

--- a/core/src/main/java/tech/tablesaw/joining/SortMergeJoinStrategy.java
+++ b/core/src/main/java/tech/tablesaw/joining/SortMergeJoinStrategy.java
@@ -1,0 +1,168 @@
+package tech.tablesaw.joining;
+
+import tech.tablesaw.api.ColumnType;
+import tech.tablesaw.api.Row;
+import tech.tablesaw.api.Table;
+import tech.tablesaw.selection.Selection;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+
+public abstract class SortMergeJoinStrategy {
+    protected int[] rightJoinColumnPositions;
+    protected int[] leftJoinColumnPositions;
+
+    public SortMergeJoinStrategy(int[] rightJoinColumnPositions, int[] leftJoinColumnPositions){
+        this.rightJoinColumnPositions = rightJoinColumnPositions;
+        this.leftJoinColumnPositions = leftJoinColumnPositions;
+    }
+
+    abstract void perform(Table result, Table left, Table right, int[] ignoreColumns);
+
+    protected void joinInner(Table destination, Table left, Table right, int[] ignoreColumns) {
+
+        Comparator<Row> comparator = getRowComparator(left, rightJoinColumnPositions);
+
+        Row leftRow = left.row(0);
+        Row rightRow = right.row(0);
+
+        // Marks the position of the first record in right table that matches a specific join value
+        int mark = -1;
+
+        while (leftRow.hasNext() || rightRow.hasNext()) {
+            if (mark == -1) {
+                while (comparator.compare(leftRow, rightRow) < 0 && leftRow.hasNext()) leftRow.next();
+                while (comparator.compare(leftRow, rightRow) > 0 && rightRow.hasNext()) rightRow.next();
+                // set the position of the first matching record on the right side
+                mark = rightRow.getRowNumber();
+            }
+            if (comparator.compare(leftRow, rightRow) == 0 && (leftRow.hasNext() || rightRow.hasNext())) {
+                addValues(destination, leftRow, rightRow);
+                if (rightRow.hasNext()) {
+                    rightRow.next();
+                } else {
+                    rightRow.at(mark);
+                    if (leftRow.hasNext()) {
+                        leftRow.next();
+                    }
+                    mark = -1;
+                }
+            } else {
+                if (rightRow.hasNext() && leftRow.hasNext()) {
+                    rightRow.at(mark);
+                    leftRow.next();
+                    mark = -1;
+                } else {
+                    if (leftRow.hasNext()) leftRow.next();
+                    if (!leftRow.hasNext()) {
+                        break;
+                    }
+                }
+            }
+        }
+        // add the last value if you end on a match
+        if (comparator.compare(leftRow, rightRow) == 0) {
+            addValues(destination, leftRow, rightRow);
+        }
+    }
+
+    private Comparator<Row> getRowComparator(Table left, int[] rightJoinColumnIndexes) {
+        List<ColumnIndexPair> pairs = createJoinColumnPairs(left, rightJoinColumnIndexes);
+        return SortKey.getChain(SortKey.create(pairs));
+    }
+
+    private List<ColumnIndexPair> createJoinColumnPairs(Table left, int[] rightJoinColumnIndexes) {
+        List<ColumnIndexPair> pairs = new ArrayList<>();
+        for (int i = 0; i < leftJoinColumnPositions.length; i++) {
+            ColumnIndexPair columnIndexPair =
+                    new ColumnIndexPair(
+                            left.column(leftJoinColumnPositions[i]).type(),
+                            leftJoinColumnPositions[i],
+                            rightJoinColumnIndexes[i]);
+            pairs.add(columnIndexPair);
+        }
+        return pairs;
+    }
+
+    private void addValues(Table destination, Row leftRow, Row rightRow) {
+
+        Row destRow = destination.appendRow();
+
+        // update positionally, but take into account the RECORD_ID COLUMNS at the end of the dest table
+        int leftColumnCount = leftRow.columnCount();
+        int rightColumnCount = rightRow.columnCount();
+
+        // update from the left table first (everythint but the RECORD_ID column)
+        for (int destIdx1 = 0; destIdx1 < leftColumnCount - 1; destIdx1++) {
+            updateDestinationRow(destRow, leftRow, destIdx1, destIdx1);
+        }
+
+        // update from the right table (everythint but the RECORD_ID column)
+        for (int destIdx2 = (leftColumnCount - 1);
+             destIdx2 < (leftColumnCount + rightColumnCount) - 2;
+             destIdx2++) {
+            int rightIndex = destIdx2 - (leftColumnCount - 1);
+            updateDestinationRow(destRow, rightRow, destIdx2, rightIndex);
+        }
+
+        // update the RECORD_ID columns
+        updateDestinationRow(destRow, leftRow, destRow.columnCount() - 2, leftColumnCount - 1);
+        updateDestinationRow(destRow, rightRow, destRow.columnCount() - 1, rightColumnCount - 1);
+    }
+
+    private void updateDestinationRow(
+            Row destRow, Row sourceRow, int destColumnPosition, int sourceColumnPosition) {
+        ColumnType type = destRow.getColumnType(destColumnPosition);
+        if (type.equals(ColumnType.INTEGER)) {
+            destRow.setInt(destColumnPosition, sourceRow.getInt(sourceColumnPosition));
+        } else if (type.equals(ColumnType.LONG)) {
+            destRow.setLong(destColumnPosition, sourceRow.getLong(sourceColumnPosition));
+        } else if (type.equals(ColumnType.SHORT)) {
+            destRow.setShort(destColumnPosition, sourceRow.getShort(sourceColumnPosition));
+        } else if (type.equals(ColumnType.STRING)) {
+            destRow.setString(destColumnPosition, sourceRow.getString(sourceColumnPosition));
+        } else if (type.equals(ColumnType.LOCAL_DATE)) {
+            destRow.setPackedDate(destColumnPosition, sourceRow.getPackedDate(sourceColumnPosition));
+        } else if (type.equals(ColumnType.LOCAL_TIME)) {
+            destRow.setPackedTime(destColumnPosition, sourceRow.getPackedTime(sourceColumnPosition));
+        } else if (type.equals(ColumnType.LOCAL_DATE_TIME)) {
+            destRow.setPackedDateTime(
+                    destColumnPosition, sourceRow.getPackedDateTime(sourceColumnPosition));
+        } else if (type.equals(ColumnType.INSTANT)) {
+            destRow.setPackedInstant(
+                    destColumnPosition, sourceRow.getPackedInstant(sourceColumnPosition));
+        } else if (type.equals(ColumnType.DOUBLE)) {
+            destRow.setDouble(destColumnPosition, sourceRow.getDouble(sourceColumnPosition));
+        } else if (type.equals(ColumnType.FLOAT)) {
+            destRow.setFloat(destColumnPosition, sourceRow.getFloat(sourceColumnPosition));
+        } else if (type.equals(ColumnType.BOOLEAN)) {
+            destRow.setBooleanAsByte(
+                    destColumnPosition, sourceRow.getBooleanAsByte(sourceColumnPosition));
+        }
+    }
+
+    protected void addLeftOnlyValues(Table destination, Table left, Selection unmatched) {
+        for (Row leftRow : left.where(unmatched)) {
+            Row destRow = destination.appendRow();
+            for (int c = 0; c < leftRow.columnCount() - 1; c++) {
+                updateDestinationRow(destRow, leftRow, c, c);
+            }
+            // update the index column putting it at the end of the destination table
+            updateDestinationRow(destRow, leftRow, destRow.columnCount() - 2, leftRow.columnCount() - 1);
+        }
+    }
+
+    protected void addRightOnlyValues(Table destination, Table left, Table right, Selection unmatched) {
+        int leftColumnCount = left.columnCount();
+        for (Row rightRow : right.where(unmatched)) {
+            Row destRow = destination.appendRow();
+            for (int c = 0; c < rightRow.columnCount() - 1; c++) {
+                updateDestinationRow(destRow, rightRow, c + leftColumnCount - 1, c);
+            }
+            // update the index column putting it at the end of the destination table
+            updateDestinationRow(
+                    destRow, rightRow, destRow.columnCount() - 1, rightRow.columnCount() - 1);
+        }
+    }
+}

--- a/core/src/main/java/tech/tablesaw/joining/SortMergeLeftJoin.java
+++ b/core/src/main/java/tech/tablesaw/joining/SortMergeLeftJoin.java
@@ -1,0 +1,25 @@
+package tech.tablesaw.joining;
+
+import tech.tablesaw.api.Table;
+import tech.tablesaw.selection.Selection;
+
+public class SortMergeLeftJoin extends SortMergeJoinStrategy{
+    private final String LEFT_RECORD_ID_NAME;
+
+    public SortMergeLeftJoin(int[] rightJoinColumnPositions, int[] leftJoinColumnPositions,
+                             String LEFT_RECORD_ID_NAME) {
+        super(rightJoinColumnPositions, leftJoinColumnPositions);
+        this.LEFT_RECORD_ID_NAME = LEFT_RECORD_ID_NAME;
+    }
+
+    @Override
+    public void perform(Table destination, Table left, Table right, int[] ignoreColumns) {
+        joinInner(destination, left, right, ignoreColumns);
+        Selection unmatched =
+                left.intColumn(LEFT_RECORD_ID_NAME)
+                        .isNotIn(destination.intColumn(LEFT_RECORD_ID_NAME).unique());
+        addLeftOnlyValues(destination, left, unmatched);
+    }
+
+
+}

--- a/core/src/main/java/tech/tablesaw/joining/SortMergeRightJoin.java
+++ b/core/src/main/java/tech/tablesaw/joining/SortMergeRightJoin.java
@@ -1,0 +1,25 @@
+package tech.tablesaw.joining;
+
+import tech.tablesaw.api.Table;
+import tech.tablesaw.selection.Selection;
+
+public class SortMergeRightJoin extends SortMergeJoinStrategy{
+    private final String RIGHT_RECORD_ID_NAME;
+
+    public SortMergeRightJoin(int[] rightJoinColumnPositions, int[] leftJoinColumnPositions, String RIGHT_RECORD_ID_NAME) {
+        super(rightJoinColumnPositions, leftJoinColumnPositions);
+        this.RIGHT_RECORD_ID_NAME = RIGHT_RECORD_ID_NAME;
+    }
+
+    @Override
+    void perform(Table destination, Table left, Table right, int[] ignoreColumns) {
+        joinInner(destination, left, right, ignoreColumns);
+        Selection unmatched =
+                right
+                        .intColumn(RIGHT_RECORD_ID_NAME)
+                        .isNotIn(destination.intColumn(RIGHT_RECORD_ID_NAME).unique());
+        addRightOnlyValues(destination, left, right, unmatched);
+    }
+
+
+}


### PR DESCRIPTION
target
- SortMergeJoinPerformer

detail
- Apply strategy pattern to SortMergeJoin perform

reason
- To change the behavior flexibly by separating the actual internal behavior into external algorithm objects