### PR TITLE
Change SortUtils class as an IntComparator Factory

### DIFF
--- a/core/src/main/java/tech/tablesaw/analytic/AnalyticQueryEngine.java
+++ b/core/src/main/java/tech/tablesaw/analytic/AnalyticQueryEngine.java
@@ -2,6 +2,8 @@ package tech.tablesaw.analytic;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Optional;
+
+import it.unimi.dsi.fastutil.ints.IntComparator;
 import tech.tablesaw.analytic.ArgumentList.FunctionCall;
 import tech.tablesaw.api.Row;
 import tech.tablesaw.api.Table;
@@ -20,7 +22,7 @@ import tech.tablesaw.table.TableSlice;
 final class AnalyticQueryEngine {
   private final AnalyticQuery query;
   private final Table destination;
-  private final IntComparatorChain rowComparator;
+  private final IntComparator rowComparator;
 
   private AnalyticQueryEngine(AnalyticQuery query) {
     this.query = query;

--- a/core/src/main/java/tech/tablesaw/api/Table.java
+++ b/core/src/main/java/tech/tablesaw/api/Table.java
@@ -712,7 +712,7 @@ public class Table extends Relation implements Iterable<Row> {
       IntComparator comparator = SortUtils.getComparator(this, key);
       return parallelSortOn(comparator);
     }
-    IntComparatorChain chain = SortUtils.getChain(this, key);
+    IntComparator chain = SortUtils.getChain(this, key);
     return parallelSortOn(chain);
   }
 

--- a/core/src/main/java/tech/tablesaw/sorting/SortUtils.java
+++ b/core/src/main/java/tech/tablesaw/sorting/SortUtils.java
@@ -14,7 +14,7 @@ public class SortUtils {
   private SortUtils() {}
 
   /** Returns a comparator chain for sorting according to the given key */
-  public static IntComparatorChain getChain(Table table, Sort key) {
+  public static IntComparator getChain(Table table, Sort key) {
     Iterator<Map.Entry<String, Sort.Order>> entries = key.iterator();
     Map.Entry<String, Sort.Order> sort = entries.next();
     Column<?> column = table.column(sort.getKey());

--- a/core/src/main/java/tech/tablesaw/sorting/comparators/DescendingIntComparator.java
+++ b/core/src/main/java/tech/tablesaw/sorting/comparators/DescendingIntComparator.java
@@ -20,9 +20,10 @@ import javax.annotation.concurrent.Immutable;
 
 /** A Comparator for sorting int primitives in descending order */
 @Immutable
-public final class DescendingIntComparator {
+public class DescendingIntComparator implements IntComparator {
 
-  public static IntComparator instance() {
-    return IntComparators.OPPOSITE_COMPARATOR;
+  @Override
+  public int compare(int o1, int o2) {
+    return Integer.compare(o2, o1);
   }
 }

--- a/core/src/main/java/tech/tablesaw/table/TableSlice.java
+++ b/core/src/main/java/tech/tablesaw/table/TableSlice.java
@@ -301,7 +301,7 @@ public class TableSlice extends Relation {
       IntComparator comparator = SortUtils.getComparator(table, key);
       this.sortOrder = sortOn(comparator);
     } else {
-      IntComparatorChain chain = SortUtils.getChain(table, key);
+      IntComparator chain = SortUtils.getChain(table, key);
       this.sortOrder = sortOn(chain);
     }
   }


### PR DESCRIPTION
## target
- SortUtils

## detail
- Unify the interface of IntComparators
- Change SortUtils class as an IntComparator Factory

## reason
- Remove dependencies for IntComparator implementations
